### PR TITLE
Block players from warping multiple times

### DIFF
--- a/src/main/java/github/gilbertokpl/essentialsk/configs/GeneralLang.java
+++ b/src/main/java/github/gilbertokpl/essentialsk/configs/GeneralLang.java
@@ -205,6 +205,8 @@ public class GeneralLang {
     public static String warpsWarpCreated;
 
     public static String warpsWarpRemoved;
+    
+    public static String warpsInTeleport;
 
     public static String tpTeleportedSuccess;
 

--- a/src/main/kotlin/github/gilbertokpl/essentialsk/commands/CommandWarp.kt
+++ b/src/main/kotlin/github/gilbertokpl/essentialsk/commands/CommandWarp.kt
@@ -73,6 +73,11 @@ class CommandWarp : CommandCreator {
             s.sendMessage(GeneralLang.warpsTeleported.replace("%warp%", warpName))
             return false
         }
+        
+        if (DataManager.inTeleport.contains(s)) {
+            p.sendMessage(GeneralLang.warpsInTeleport)
+            return false
+        }
 
         val time = MainConfig.warpsTimeToTeleport
 


### PR DESCRIPTION
Fixes the issue that allows players to teleport multiple times in a row using the warp command.