### PR TITLE
Fix StackMobs error with MCPCTotal Bukkit

### DIFF
--- a/src/main/kotlin/github/gilbertokpl/total/stackmobs/StackMobsManager.kt
+++ b/src/main/kotlin/github/gilbertokpl/total/stackmobs/StackMobsManager.kt
@@ -30,15 +30,25 @@ object StackMobsManager {
 
     private fun findNearbyStackedMob(entity: LivingEntity): LivingEntity? {
         val radius = MainConfig.stackmobsRadius.toDouble()
-        val nearbyEntities = entity.getNearbyEntities(radius, radius, radius)
+        val radiusSquared = radius * radius
+        val entityLocation = entity.location
 
-        return nearbyEntities
+        // Use world.entities instead of getNearbyEntities to avoid MCPCTotal entity tracking issues
+        return entity.world.entities
             .filterIsInstance<LivingEntity>()
-            .firstOrNull { nearby ->
-                nearby.type == entity.type &&
-                        !nearby.isDead &&
-                        nearby.hasMetadata(STACK_METADATA_KEY)
+            .filter { nearby ->
+                if (nearby == entity || nearby.isDead) return@filter false
+                if (nearby.type != entity.type) return@filter false
+                if (!nearby.hasMetadata(STACK_METADATA_KEY)) return@filter false
+
+                // Manual distance check
+                val nearbyLocation = nearby.location
+                if (nearbyLocation.world != entityLocation.world) return@filter false
+
+                val distanceSquared = entityLocation.distanceSquared(nearbyLocation)
+                distanceSquared <= radiusSquared
             }
+            .firstOrNull()
     }
 
     private fun stackMobsWithinRange(target: LivingEntity, source: LivingEntity) {


### PR DESCRIPTION
Replaced entity.getNearbyEntities() with manual distance calculation using world.entities to avoid incompatible entity tracking calls in MCPCTotal/MCPC+.

The original implementation used entity.getNearbyEntities() which internally accesses the EntityTracker in a way that MCPCTotal blocks. The new implementation uses entity.world.entities and manually filters by distance using distanceSquared, which is compatible with MCPCTotal and avoids the entity tracking error.

Fixes the error:
"Plugin attempted to use entity tracking with MCPCTotal/MCPCBuilder. This is not supported. Plugins should use EntityTracker in the entity's registered world instead of reflection."