### PR TITLE
Fix player registration and force update issues

### DIFF
--- a/src/main/kotlin/github/gilbertokpl/core/cache/CacheManager.kt
+++ b/src/main/kotlin/github/gilbertokpl/core/cache/CacheManager.kt
@@ -85,6 +85,10 @@ class CacheManager private constructor(
             totalCore.logger.log(message)
         }
 
+        override fun log(message: String, level: Int) {
+            totalCore.logger.log(message, level)
+        }
+
         override fun warn(message: String) {
             totalCore.logger.log("[WARN] $message")
         }

--- a/src/main/kotlin/github/gilbertokpl/core/cache/builder/AbstractCacheBuilder.kt
+++ b/src/main/kotlin/github/gilbertokpl/core/cache/builder/AbstractCacheBuilder.kt
@@ -1,0 +1,192 @@
+package github.gilbertokpl.core.cache.builder
+
+import github.gilbertokpl.core.cache.interfaces.ICacheBuilder
+import github.gilbertokpl.core.cache.interfaces.ICacheLogger
+import org.bukkit.entity.Player
+import org.jetbrains.exposed.v1.core.Column
+import org.jetbrains.exposed.v1.core.Table
+import java.util.concurrent.locks.ReentrantReadWriteLock
+import kotlin.concurrent.read
+import kotlin.concurrent.write
+
+/**
+ * Classe base abstrata para builders de cache com persistência.
+ *
+ * Fornece:
+ * - Normalização de chaves (lowercase)
+ * - Thread-safety via ReadWriteLock
+ * - Gerenciamento de pendências de update
+ * - Estrutura comum para persistência
+ *
+ * @param T Tipo do valor no cache
+ * @param D Tipo do valor no banco de dados
+ */
+abstract class AbstractCacheBuilder<T, D>(
+    protected val table: Table,
+    protected val primaryColumn: Column<String>,
+    protected val column: Column<D>,
+    protected val logger: ICacheLogger
+) : ICacheBuilder<T> {
+
+    // Cache em memória
+    protected val cache = HashMap<String, T?>()
+
+    // Lock para thread-safety
+    protected val rwLock = ReentrantReadWriteLock()
+
+    // Chaves com alterações pendentes para persistir
+    protected val pendingUpdates = mutableSetOf<String>()
+
+    // Chaves marcadas para deleção (limpar valor, não deletar linha)
+    protected val markedForDeletion = mutableSetOf<String>()
+
+    // =========================================================
+    // Métodos abstratos para conversão
+    // =========================================================
+
+    /**
+     * Converte valor do cache para formato do banco.
+     */
+    protected abstract fun toDatabase(value: T): D
+
+    /**
+     * Converte valor do banco para formato do cache.
+     */
+    protected abstract fun fromDatabase(value: D): T?
+
+    // =========================================================
+    // Métodos opcionais para override
+    // =========================================================
+
+    /**
+     * Valor default para novas entradas.
+     * Override para tipos com valor default específico.
+     */
+    protected open fun defaultValue(): T? = null
+
+    /**
+     * Determina se um valor deve ser tratado como "deletado".
+     * Override para lógica customizada.
+     */
+    protected open fun shouldDelete(value: T?): Boolean = value == null
+
+    // =========================================================
+    // Normalização de chaves
+    // =========================================================
+
+    /**
+     * Normaliza a chave para lowercase.
+     * Garante consistência entre cache e banco.
+     */
+    protected fun normalizeKey(key: String): String = key.lowercase()
+
+    /**
+     * Marca uma chave para ser persistida no próximo update.
+     */
+    protected fun markForUpdate(key: String) {
+        pendingUpdates.add(key)
+    }
+
+    // =========================================================
+    // Implementação de ICacheBuilder - Leitura
+    // =========================================================
+
+    override fun getMap(): Map<String, T?> {
+        rwLock.read {
+            return cache.toMap()
+        }
+    }
+
+    override operator fun get(entity: String): T? {
+        rwLock.read {
+            return cache[normalizeKey(entity)]
+        }
+    }
+
+    override operator fun get(entity: Player): T? = get(entity.name)
+
+    override fun contains(entity: String): Boolean {
+        rwLock.read {
+            return cache.containsKey(normalizeKey(entity))
+        }
+    }
+
+    override fun contains(entity: Player): Boolean = contains(entity.name)
+
+    override fun size(): Int {
+        rwLock.read {
+            return cache.size
+        }
+    }
+
+    override fun hasPendingUpdates(): Boolean {
+        rwLock.read {
+            return pendingUpdates.isNotEmpty()
+        }
+    }
+
+    // =========================================================
+    // Implementação de ICacheBuilder - Escrita
+    // =========================================================
+
+    override operator fun set(entity: String, value: T) {
+        set(entity, value, override = true)
+    }
+
+    override operator fun set(entity: Player, value: T) {
+        set(entity.name, value)
+    }
+
+    /**
+     * Implementação padrão de set com override.
+     * Subclasses podem sobrescrever para comportamento específico.
+     */
+    override operator fun set(entity: String, value: T, override: Boolean) {
+        val key = normalizeKey(entity)
+        rwLock.write {
+            cache[key] = value
+            markedForDeletion.remove(key)
+            markForUpdate(key)
+        }
+    }
+
+    override fun remove(entity: String) {
+        val key = normalizeKey(entity)
+        rwLock.write {
+            cache.remove(key)
+            markedForDeletion.add(key)
+            markForUpdate(key)
+        }
+    }
+
+    override fun remove(entity: Player) = remove(entity.name)
+
+    // =========================================================
+    // Ciclo de vida - devem ser implementados pelas subclasses
+    // =========================================================
+
+    /**
+     * Persiste alterações pendentes no banco.
+     * Subclasses devem implementar a lógica de UPDATE.
+     */
+    abstract override fun update()
+
+    /**
+     * Carrega dados do banco para o cache.
+     * Subclasses devem implementar a lógica de SELECT.
+     */
+    abstract override fun load()
+
+    /**
+     * Salva e limpa recursos.
+     * Implementação padrão: update + clear.
+     */
+    override fun unload() {
+        update()
+        rwLock.write {
+            cache.clear()
+            pendingUpdates.clear()
+            markedForDeletion.clear()
+        }
+    }
+}

--- a/src/main/kotlin/github/gilbertokpl/core/cache/builder/ByteBuilder.kt
+++ b/src/main/kotlin/github/gilbertokpl/core/cache/builder/ByteBuilder.kt
@@ -60,7 +60,7 @@ internal class ByteBuilder<T>(
                         // Existe no banco - faz UPDATE (mesmo se value for null, apenas limpa)
                         originalKey != null -> {
                             if (value != null) {
-                                logger.log("Atualizando entidade: $key, coluna: ${column.name}, valor: $value")
+                                logger.log("Atualizando entidade: $key, coluna: ${column.name}, valor: $value", 2)
                                 table.update({ primaryColumn eq originalKey }) {
                                     it[column] = value
                                 }

--- a/src/main/kotlin/github/gilbertokpl/core/cache/builder/HashMapBuilder.kt
+++ b/src/main/kotlin/github/gilbertokpl/core/cache/builder/HashMapBuilder.kt
@@ -162,7 +162,7 @@ class HashMapBuilder<K, V, D>(
                     when {
                         // Existe no banco - faz UPDATE
                         originalKey != null -> {
-                            logger.log("Atualizando entidade: $key, coluna: ${column.name}")
+                            logger.log("Atualizando entidade: $key, coluna: ${column.name}", 2)
                             table.update({ primaryColumn eq originalKey }) {
                                 it[column] = dbValue
                             }

--- a/src/main/kotlin/github/gilbertokpl/core/cache/builder/ListBuilder.kt
+++ b/src/main/kotlin/github/gilbertokpl/core/cache/builder/ListBuilder.kt
@@ -124,7 +124,7 @@ internal class ListBuilder<V, D>(
                     when {
                         // Existe no banco - faz UPDATE
                         originalKey != null -> {
-                            logger.log("Atualizando entidade: $key, coluna: ${column.name}")
+                            logger.log("Atualizando entidade: $key, coluna: ${column.name}", 2)
                             table.update({ primaryColumn eq originalKey }) {
                                 it[column] = dbValue
                             }

--- a/src/main/kotlin/github/gilbertokpl/core/cache/builder/LocationBuilder.kt
+++ b/src/main/kotlin/github/gilbertokpl/core/cache/builder/LocationBuilder.kt
@@ -84,9 +84,9 @@ internal class LocationBuilder(
                         // Existe no banco - faz UPDATE (mesmo se null, apenas limpa para "")
                         originalKey != null -> {
                             if (value != null) {
-                                logger.log("Atualizando location: $key, coluna: ${column.name}")
+                                logger.log("Atualizando location: $key, coluna: ${column.name}", 2)
                             } else {
-                                logger.log("Limpando location: $key, coluna: ${column.name}")
+                                logger.log("Limpando location: $key, coluna: ${column.name}", 2)
                             }
                             table.update({ primaryColumn eq originalKey }) {
                                 it[column] = dbValue
@@ -129,7 +129,7 @@ internal class LocationBuilder(
                 if (isDisabledWorld) {
                     cache[key] = null
                     markForUpdate(key) // Vai limpar no banco
-                    logger.log("Location ignorada (mundo desabilitado): $key, mundo: $worldName")
+                    logger.log("Location ignorada (mundo desabilitado): $key, mundo: $worldName", 2)
                 } else {
                     cache[key] = location
                 }

--- a/src/main/kotlin/github/gilbertokpl/core/cache/interfaces/ICacheErrorHandler.kt
+++ b/src/main/kotlin/github/gilbertokpl/core/cache/interfaces/ICacheErrorHandler.kt
@@ -1,0 +1,8 @@
+package github.gilbertokpl.core.cache.interfaces
+
+/**
+ * Interface funcional para tratamento de erros do cache.
+ */
+fun interface ICacheErrorHandler {
+    fun onError(message: String, throwable: Throwable)
+}

--- a/src/main/kotlin/github/gilbertokpl/core/cache/interfaces/ICacheLogger.kt
+++ b/src/main/kotlin/github/gilbertokpl/core/cache/interfaces/ICacheLogger.kt
@@ -1,0 +1,30 @@
+package github.gilbertokpl.core.cache.interfaces
+
+/**
+ * Interface para logging do sistema de cache.
+ */
+interface ICacheLogger {
+    /**
+     * Log de informação.
+     */
+    fun log(message: String)
+
+    /**
+     * Log de informação com nível.
+     * Nível 1 = essencial, Nível 2 = detalhado
+     */
+    fun log(message: String, level: Int) {
+        // Default: ignora nível, sempre loga
+        log(message)
+    }
+
+    /**
+     * Log de aviso.
+     */
+    fun warn(message: String)
+
+    /**
+     * Log de erro com exceção opcional.
+     */
+    fun error(message: String, throwable: Throwable? = null)
+}

--- a/src/main/kotlin/github/gilbertokpl/core/utils/FileLogger.kt
+++ b/src/main/kotlin/github/gilbertokpl/core/utils/FileLogger.kt
@@ -11,6 +11,13 @@ class FileLogger {
     private val logDir = File("plugins/TotalEssentials/log")
     private val logFile = File(logDir, "log.txt")
 
+    /**
+     * Nível de log:
+     * 1 = Apenas logs essenciais (erros, início/fim)
+     * 2 = Logs detalhados (cada atualização individual)
+     */
+    var logLevel: Int = 1
+
     init {
         if (!logDir.exists()) {
             logDir.mkdirs()
@@ -33,6 +40,15 @@ class FileLogger {
             writer.close()
         } catch (e: IOException) {
             e.printStackTrace()
+        }
+    }
+
+    /**
+     * Log com nível - só grava se logLevel >= level
+     */
+    fun log(message: String, level: Int) {
+        if (logLevel >= level) {
+            log(message)
         }
     }
 }

--- a/src/main/kotlin/github/gilbertokpl/total/cache/data/KitsData.kt
+++ b/src/main/kotlin/github/gilbertokpl/total/cache/data/KitsData.kt
@@ -23,16 +23,18 @@ object KitsData : ICache {
     }
 
     fun createNewKitData(entity: String) {
-        kitFakeName[entity] = ""
-        kitTime[entity] = 0L
-        kitItems[entity] = arrayListOf()
-        kitWeight[entity] = 0
+        val key = entity.lowercase()
+        kitFakeName[key] = ""
+        kitTime[key] = 0L
+        kitItems[key] = arrayListOf()
+        kitWeight[key] = 0
     }
 
     fun delete(entity: String) {
-        kitFakeName.remove(entity)
-        kitTime.remove(entity)
-        kitItems.remove(entity)
-        kitWeight.remove(entity)
+        val key = entity.lowercase()
+        kitFakeName.remove(key)
+        kitTime.remove(key)
+        kitItems.remove(key)
+        kitWeight.remove(key)
     }
 }

--- a/src/main/kotlin/github/gilbertokpl/total/cache/data/LoginData.kt
+++ b/src/main/kotlin/github/gilbertokpl/total/cache/data/LoginData.kt
@@ -36,8 +36,9 @@ object LoginData : ICache {
     }
 
     fun createNewLoginData(playerName: String, password: String, ipAddress: String) {
-        isLoggedIn[playerName] = true
-        this.password[playerName] = password
-        this.ipAddress[playerName] = ipAddress
+        val key = playerName.lowercase()
+        isLoggedIn[key] = true
+        this.password[key] = password
+        this.ipAddress[key] = ipAddress
     }
 }


### PR DESCRIPTION
- Create missing AbstractCacheBuilder class that was referenced but not defined
- Create missing ICacheLogger and ICacheErrorHandler interfaces
- Fix KitsData.createNewKitData to use lowercase keys (was causing kits to always update)
- Fix LoginData.createNewLoginData to ensure lowercase is used consistently
- Add log level system to FileLogger (default level 1 = essential logs only)
- Update all builders to use log level 2 for detailed update logs

This fixes:
- Kits always appearing in forceupdate/forcesave
- Players losing /register data due to case mismatch